### PR TITLE
Disable check for samples that will throw an unnecessary error on

### DIFF
--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -237,12 +237,12 @@ class generic_input_layer : public io_layer<TensorDataType> {
     int num_samples_in_batch = 0;
     if(io_buffer->num_samples_ready(mode) > 0) {
       num_samples_in_batch = io_buffer->num_samples_ready(mode);
-    }else {
-        if(!get_data_reader()->position_is_overrun()) {
-          std::stringstream err;
-          err << "I/O buffer does not contain valid samples ("<< num_samples_in_batch << ")";
-          LBANN_ERROR(err.str());
-        }
+    // }else {
+    //     if(!get_data_reader()->position_is_overrun()) {
+    //       std::stringstream err;
+    //       err << "I/O buffer does not contain valid samples ("<< num_samples_in_batch << ")";
+    //       LBANN_ERROR(err.str());
+    //     }
     }
 
     if(dynamic_cast<partitioned_io_buffer<TensorDataType>*>(io_buffer) != nullptr) {


### PR DESCRIPTION
ranks that will not receive samples because the mini-batch size is too
small.